### PR TITLE
Import UIKit/Cocoa headers to fix compile error

### DIFF
--- a/BBHTTP/Handlers/BBHTTPImageDecoder.m
+++ b/BBHTTP/Handlers/BBHTTPImageDecoder.m
@@ -19,6 +19,12 @@
 //  Copyright (c) 2013 BiasedBit. All rights reserved.
 //
 
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+   #import <UIKit/UIKit.h>
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+   #import <Cocoa/Cocoa.h>
+#endif
+
 #import "BBHTTPImageDecoder.h"
 
 #import "BBHTTPUtils.h"


### PR DESCRIPTION
It was complaining that NSImage was a forward class declaration.
