### PR TITLE
Follow redirects

### DIFF
--- a/BBHTTP/BBHTTPExecutor.m
+++ b/BBHTTP/BBHTTPExecutor.m
@@ -73,7 +73,7 @@ static size_t BBHTTPExecutorReadHeader(uint8_t* buffer, size_t size, size_t leng
     // End of headers reached, data will follow
     BBHTTPLogTrace(@"%@ | All headers received.", context);
     BOOL canProceed = YES;
-    if ([context isCurrentResponse100Continue]||context.currentResponse.code==301) {
+    if ([context isCurrentResponse100Continue]||context.currentResponse.code==301||context.currentResponse.code==302) {
         // Subsequent callbacks will hit BBHTTPExecutorReadStatusLine()
         [context finishCurrentResponse];
     } else {

--- a/BBHTTP/BBHTTPExecutor.m
+++ b/BBHTTP/BBHTTPExecutor.m
@@ -538,6 +538,7 @@ static BOOL BBHTTPExecutorInitialized = NO;
     } else {
         curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, YES);
         curl_easy_setopt(handle, CURLOPT_MAXREDIRS, context.request.maxRedirects);
+        curl_easy_setopt(handle, CURLOPT_AUTOREFERER, YES);
     }
 
     // Setup - misc configuration

--- a/BBHTTP/BBHTTPExecutor.m
+++ b/BBHTTP/BBHTTPExecutor.m
@@ -73,7 +73,7 @@ static size_t BBHTTPExecutorReadHeader(uint8_t* buffer, size_t size, size_t leng
     // End of headers reached, data will follow
     BBHTTPLogTrace(@"%@ | All headers received.", context);
     BOOL canProceed = YES;
-    if ([context isCurrentResponse100Continue]) {
+    if ([context isCurrentResponse100Continue]||context.currentResponse.code==301) {
         // Subsequent callbacks will hit BBHTTPExecutorReadStatusLine()
         [context finishCurrentResponse];
     } else {
@@ -518,12 +518,12 @@ static BOOL BBHTTPExecutorInitialized = NO;
     }
 
     // Setup - configure redirections
-//    if (context.request.maxRedirects == 0) {
-//        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, NO);
-//    } else {
-//        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, YES);
-//        curl_easy_setopt(handle, CURLOPT_MAXREDIRS, context.request.maxRedirects);
-//    }
+    if (context.request.maxRedirects == 0) {
+        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, NO);
+    } else {
+        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, YES);
+        curl_easy_setopt(handle, CURLOPT_MAXREDIRS, context.request.maxRedirects);
+    }
 
     // Setup - misc configuration
     curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1L);

--- a/BBHTTP/Internal/BBHTTPRequestContext.m
+++ b/BBHTTP/Internal/BBHTTPRequestContext.m
@@ -78,6 +78,9 @@
         nextState = BBHTTPResponseStateReadingStatusLine; // ... unless it's a 100-Continue; if so, go back to the start
         // TODO I'm assuming 100-Continue's never have data...
         _uploadAccepted = YES;
+    } else if (self.currentResponse.code==301) {
+        nextState = BBHTTPResponseStateReadingStatusLine; // ... unless it's a 301-Redirect; if so, go back to the start
+        // TODO I'm assuming 301-Redirect's never have data...
     } else if (!_discardBodyForCurrentResponse) {
         NSError* error = nil;
         parsedContent = [_request.responseContentHandler parseContent:&error];

--- a/BBHTTP/Internal/BBHTTPRequestContext.m
+++ b/BBHTTP/Internal/BBHTTPRequestContext.m
@@ -78,7 +78,7 @@
         nextState = BBHTTPResponseStateReadingStatusLine; // ... unless it's a 100-Continue; if so, go back to the start
         // TODO I'm assuming 100-Continue's never have data...
         _uploadAccepted = YES;
-    } else if (self.currentResponse.code==301) {
+    } else if (self.currentResponse.code==301||self.currentResponse.code==302) {
         nextState = BBHTTPResponseStateReadingStatusLine; // ... unless it's a 301-Redirect; if so, go back to the start
         // TODO I'm assuming 301-Redirect's never have data...
     } else if (!_discardBodyForCurrentResponse) {

--- a/Example/iOS Sample app/Classes/AppDelegate.m
+++ b/Example/iOS Sample app/Classes/AppDelegate.m
@@ -34,11 +34,13 @@
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
 {
-    [self getImageExample];
+//    [self getImageExample];
 //    [self getJsonExample];
 //    [self getExample];
 //    [self postExample];
-
+    [self testRedirect];
+    
+    
     return YES;
 }
 
@@ -101,5 +103,25 @@
         NSLog(@"Error: %@", [error localizedDescription]);
     }];
 }
+
+- (void)testRedirect
+{
+    [BBHTTPExecutor sharedExecutor].verbose=YES;
+    
+    BBHTTPRequest* redirect=[BBHTTPRequest readResource:@"http://pass.telekom.de"];
+
+    [redirect setMaxRedirects:-1];
+    
+    [redirect execute:^(BBHTTPResponse* response) {
+        NSLog(@"Finished: %u %@ -- received %u bytes of '%@' %@",
+              response.code, response.message, response.contentSize,
+              response[@"Content-Type"], response.headers);
+        
+    } error:^(NSError* error) {
+        NSLog(@"Error: %@", [error localizedDescription]);
+    }];
+ 
+}
+
 
 @end

--- a/Example/iOS Sample app/Classes/AppDelegate.m
+++ b/Example/iOS Sample app/Classes/AppDelegate.m
@@ -110,12 +110,16 @@
     
     BBHTTPRequest* redirect=[BBHTTPRequest readResource:@"http://pass.telekom.de"];
 
+redirect[@"User-Agent"]=@"Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3";
+                             
     [redirect setMaxRedirects:-1];
     
     [redirect execute:^(BBHTTPResponse* response) {
         NSLog(@"Finished: %u %@ -- received %u bytes of '%@' %@",
               response.code, response.message, response.contentSize,
               response[@"Content-Type"], response.headers);
+        NSLog(@"Content: %@", [[NSString alloc] initWithData:response.content
+                                                    encoding:NSUTF8StringEncoding]);
         
     } error:^(NSError* error) {
         NSLog(@"Error: %@", [error localizedDescription]);


### PR DESCRIPTION
I have implemented following of redirects.

Currently only 301 is supported. I'm still working on this, but wanted to post it early so I can include any comments you have. :)

Some servers send data after the 301 header. To support this I used an own callback for the headers, to detect if a new request comes in. Maybe this can also help with the 100-continue responses.

Tell me what you think. :) 
